### PR TITLE
Streaming txnLogs to a server via POST request implemented.

### DIFF
--- a/mock_server.go
+++ b/mock_server.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Mock server is used to test streaming
+func main2() {
+	port := "12345"
+	fmt.Println("Mock server accepting connections at localhost:" + port)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			fmt.Println("Method not supported on this endpoint!")
+			return
+		}
+
+		fmt.Println("Mock server received a connection!")
+
+		buf := make([]byte, 8096)
+
+		for {
+			n, err := r.Body.Read(buf)
+			if n > 0 {
+				fmt.Print(string(buf[:n]))
+			}
+
+			if err == io.EOF {
+				r.Body.Close()
+				break
+			}
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+		}
+	})
+
+	http.ListenAndServe(":"+port, nil)
+}

--- a/utils/json_reviver.go
+++ b/utils/json_reviver.go
@@ -19,8 +19,8 @@ func NewJSONReviver(stream io.Reader) *JSONReviver {
 	return r
 }
 
-// ParseTransactionLogs parses an incoming stream response thath contains transaction log entries.
-func (r *JSONReviver) ParseTransactionLogs(callback func(*TransactionLogEntry)) error {
+// ParseTransactionLogs parses an incoming stream response that contains transaction log entries.
+func (r *JSONReviver) ParseTransactionLogs(callback func(*TransactionLogEntry, bool)) error {
 	t, err := r.decoder.Token()
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func (r *JSONReviver) ParseTransactionLogs(callback func(*TransactionLogEntry)) 
 			}
 
 			// Give transactionLog to the callback for processing.
-			callback(&txnLog)
+			callback(&txnLog, false)
 		}
 		// End of Array
 		token, err = r.decoder.Token()
@@ -73,6 +73,9 @@ func (r *JSONReviver) ParseTransactionLogs(callback func(*TransactionLogEntry)) 
 			return errors.New("JSON array end delimiter not found")
 		}
 	}
+
+	// Done parsing
+	callback(nil, true)
 
 	return nil
 }

--- a/utils/odata.go
+++ b/utils/odata.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -84,41 +83,14 @@ func (client *Client) ExecuteGETRequestEx(urlStr string, preReq func(*http.Reque
 	return resp
 }
 
-func (client *Client) ExecutePOSTRequest(urlStr, contentType, body string) *http.Response {
-	// Create new, POST, request
-	req, _ := http.NewRequest("POST", urlStr, strings.NewReader(body))
+func (client *Client) ExecutePOSTRequest(urlStr, contentType string, stream io.ReadCloser) *http.Response {
+	req, _ := http.NewRequest("POST", urlStr, stream)
 	req.Header.Add("Content-Type", contentType)
 	// Add the OData-Version header
 	req.Header.Add("OData-Version", "4.0")
 	// We'll be expecting a JSON formatted response, set Accept header accordingly
 	req.Header.Add("Accept", "application/json")
-	if Verbose == true {
-		fmt.Println(req.Method, req.URL)
-		fmt.Println(body)
-	}
-	// Execute the request
-	resp, err := client.Do(req)
-	// If no errors then return the response
-	if err != nil {
-		log.Fatal(err)
-	}
-	return resp
-}
 
-func (client *Client) ExecutePOSTRequestEx(urlStr, contentType, body string, preReq func(*http.Request)) *http.Response {
-	// Create new, POST, request
-	req, _ := http.NewRequest("POST", urlStr, strings.NewReader(body))
-	req.Header.Add("Content-Type", contentType)
-	// Add the OData-Version header
-	req.Header.Add("OData-Version", "4.0")
-	// We'll be expecting a JSON formatted response, set Accept header accordingly
-	req.Header.Add("Accept", "application/json")
-	// Allow additional processing of the request before actually executing
-	preReq(req)
-	if Verbose == true {
-		fmt.Println(req.Method, req.URL)
-		fmt.Println(body)
-	}
 	// Execute the request
 	resp, err := client.Do(req)
 	// If no errors then return the response


### PR DESCRIPTION
- Streaming logs to a server via POST implemented,
- Also mock_client.go added to be able to start a server that will accept POST requests only (Simply copy this file to another location and modify the function name `main2` to `main` and run `go run main.go` command to start the server.).